### PR TITLE
Add Http Whiteboard Publisher

### DIFF
--- a/runtime/httpwhiteboard/.classpath
+++ b/runtime/httpwhiteboard/.classpath
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/runtime/httpwhiteboard/.project
+++ b/runtime/httpwhiteboard/.project
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>httpwhiteboard</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/runtime/httpwhiteboard/.settings/org.eclipse.core.resources.prefs
+++ b/runtime/httpwhiteboard/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,6 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding//src/test/java=UTF-8
+encoding//src/test/resources=UTF-8
+encoding/<project>=UTF-8

--- a/runtime/httpwhiteboard/.settings/org.eclipse.jdt.core.prefs
+++ b/runtime/httpwhiteboard/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=17

--- a/runtime/httpwhiteboard/.settings/org.eclipse.m2e.core.prefs
+++ b/runtime/httpwhiteboard/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/runtime/httpwhiteboard/.settings/org.eclipse.pde.core.prefs
+++ b/runtime/httpwhiteboard/.settings/org.eclipse.pde.core.prefs
@@ -1,0 +1,2 @@
+BUNDLE_ROOT_PATH=target/classes
+eclipse.preferences.version=1

--- a/runtime/httpwhiteboard/pom.xml
+++ b/runtime/httpwhiteboard/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.osgi-technology.webservices</groupId>
+		<artifactId>org.eclipse.osgi.technology.webservices.runtime</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>org.eclipse.osgi.technology.webservices.httpwhiteboard</artifactId>
+	<name>Http WHiteboard Publisher</name>
+	<description>Publish the Endpoints using Http Whiteboard Service</description>
+
+
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.osgi-technology.webservices</groupId>
+			<artifactId>
+				org.eclipse.osgi.technology.webservices.runtime.registrar</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.ws</groupId>
+			<artifactId>jakarta.xml.ws-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.annotation.bundle</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.service.component.annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.service.component</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>6.1.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.service.http.whiteboard</artifactId>
+			<version>1.1.1</version>
+			<scope>provided</scope>
+		</dependency>
+<!--		TODO can we somehow embedd the classes instead of copy the source-->
+<!--		<dependency>-->
+<!--			<groupId>com.sun.xml.ws</groupId>-->
+<!--			<artifactId>jaxws-rt</artifactId>-->
+<!--			<version>4.0.3</version>-->
+<!--			<scope>provided</scope>-->
+<!--		</dependency>-->
+	</dependencies>
+</project>

--- a/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/HttpWhiteboardPublisher.java
+++ b/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/HttpWhiteboardPublisher.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.osgi.technology.webservices.httpwhiteboard;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.osgi.technology.webservices.spi.EndpointPublisher;
+import org.eclipse.osgi.technology.webservices.spi.PublishedEndpoint;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.http.whiteboard.annotations.RequireHttpWhiteboard;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+import org.osgi.service.webservice.whiteboard.WebserviceWhiteboardConstants;
+import org.osgi.service.webservice.whiteboard.annotations.RequireWebserviceWhiteboard;
+
+import jakarta.xml.ws.Endpoint;
+
+/**
+ * Publishes Endpoints with the HttpWhiteboard service
+ *
+ */
+@RequireHttpWhiteboard
+@RequireWebserviceWhiteboard
+@Component(immediate = true, name = "org.eclipse.osgi.technology.webservices.httpwhiteboard", service = EndpointPublisher.class)
+public class HttpWhiteboardPublisher implements EndpointPublisher {
+
+	private BundleContext bundleContext;
+	private Logger logger;
+	private Map<Endpoint, WhiteboardHttpContext> registrationMap = new ConcurrentHashMap<>();
+
+	/**
+	 * Constructor
+	 * 
+	 * @param bundleContext the context
+	 * @param logger        the logger
+	 */
+	@Activate
+	public HttpWhiteboardPublisher(BundleContext bundleContext,
+			@Reference(service = LoggerFactory.class) Logger logger) {
+		this.bundleContext = bundleContext;
+		this.logger = logger;
+	}
+
+	@Override
+	public PublishedEndpoint publishEndpoint(Endpoint endpoint) {
+		Map<String, Object> properties = endpoint.getProperties();
+		Object prefix = properties.get(WebserviceWhiteboardConstants.WEBSERVICE_HTTP_ENDPOINT_PREFIX);
+		if (prefix instanceof String contextPath) {
+			logger.info("Registering {} with http whiteboard at context path {}", endpoint, contextPath);
+			WhiteboardHttpContext httpContext = new WhiteboardHttpContext(contextPath, endpoint.getProperties());
+			registrationMap.put(endpoint, httpContext);
+			endpoint.publish(httpContext);
+			httpContext.register(bundleContext);
+			return httpContext;
+		}
+		return null;
+	}
+
+}

--- a/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/WhiteboardHttpContext.java
+++ b/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/WhiteboardHttpContext.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.osgi.technology.webservices.httpwhiteboard;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.osgi.technology.webservices.httpwhiteboard.wsri.EndpointHttpExchange;
+import org.eclipse.osgi.technology.webservices.spi.PublishedEndpoint;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.xml.ws.spi.http.HttpContext;
+
+/**
+ * Http context to use with the whiteboard
+ */
+public class WhiteboardHttpContext extends HttpContext implements PublishedEndpoint {
+
+	private String path;
+	private Map<String, ?> attributes;
+	private Set<String> names;
+	private boolean closed;
+	private ServiceRegistration<?> serviceRegistration;
+
+	WhiteboardHttpContext(String path, Map<String, ?> attributes) {
+		this.path = path;
+		this.attributes = attributes;
+		names = Collections.unmodifiableSet(attributes.keySet());
+	}
+
+	@Override
+	public String getPath() {
+		return path;
+	}
+
+	@Override
+	public Object getAttribute(String name) {
+		return attributes.get(name);
+	}
+
+	@Override
+	public Set<String> getAttributeNames() {
+		return names;
+	}
+
+	synchronized void register(BundleContext bundleContext) {
+		if (closed) {
+			return;
+		}
+		HashMap<String, Object> properties = new HashMap<>(attributes);
+		if (!properties.containsKey(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME)) {
+			properties.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME, "JAX-WS Service for path "+getPath());
+		}
+		properties.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, getPath());
+        serviceRegistration = bundleContext.registerService(Servlet.class, new JaxWsServlet(), FrameworkUtil.asDictionary(properties));
+	}
+
+	private class JaxWsServlet extends HttpServlet {
+
+		private static final long serialVersionUID = 1L;
+
+
+		@Override
+		protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+			if (handler == null || closed) {
+				resp.sendError(HttpURLConnection.HTTP_UNAVAILABLE);
+				return;
+			}
+			handler.handle(new EndpointHttpExchange(req, resp, getServletContext(), WhiteboardHttpContext.this));
+		}
+
+	}
+
+	@Override
+	public synchronized void unpublish() {
+		closed = true;
+		if (serviceRegistration != null) {
+			serviceRegistration.unregister();
+		}
+	}
+
+	@Override
+	public String getAddress() {
+		// FIXME we need the full path here, how to get it from the whiteboard?!?
+		return path;
+	}
+
+}

--- a/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/wsri/EndpointHttpExchange.java
+++ b/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/wsri/EndpointHttpExchange.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.eclipse.osgi.technology.webservices.httpwhiteboard.wsri;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.security.Principal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.xml.ws.handler.MessageContext;
+import jakarta.xml.ws.spi.http.HttpContext;
+import jakarta.xml.ws.spi.http.HttpExchange;
+
+/**
+ * @author Jitendra Kotamraju
+*/
+public final class EndpointHttpExchange extends HttpExchange {
+    private final HttpServletRequest req;
+    private final HttpServletResponse res;
+    private final ExchangeRequestHeaders reqHeaders;
+    private final ExchangeResponseHeaders resHeaders;
+    private final ServletContext servletContext;
+    private final HttpContext httpContext;
+    private static final Set<String> attributes = new HashSet<>();
+    static {
+        attributes.add(MessageContext.SERVLET_CONTEXT);
+        attributes.add(MessageContext.SERVLET_REQUEST);
+        attributes.add(MessageContext.SERVLET_RESPONSE);
+    }
+
+    public EndpointHttpExchange(HttpServletRequest req, HttpServletResponse res, ServletContext servletContext,
+                         HttpContext httpContext) {
+        this.req = req;
+        this.res = res;
+        this.servletContext = servletContext;
+        this.httpContext = httpContext;
+        this.reqHeaders = new ExchangeRequestHeaders(req);
+        this.resHeaders = new ExchangeResponseHeaders(res);
+    }
+
+    @Override
+    public Map<String, List<String>> getRequestHeaders() {
+        return reqHeaders;
+    }
+
+    @Override
+    public Map<String, List<String>> getResponseHeaders() {
+        return resHeaders;
+    }
+
+    @Override
+    public String getRequestURI() {
+        return req.getRequestURI();
+    }
+
+    @Override
+    public String getContextPath() {
+        return req.getContextPath();
+    }
+
+    @Override
+    public String getRequestMethod() {
+        return req.getMethod();
+    }
+
+    @Override
+    public HttpContext getHttpContext() {
+        return httpContext;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    @Override
+    public String getRequestHeader(String name) {
+        return reqHeaders.getFirst(name);
+    }
+
+    @Override
+    public void addResponseHeader(String name, String value) {
+        resHeaders.add(name, value);
+    }
+
+    @Override
+    public InputStream getRequestBody() throws IOException {
+        return req.getInputStream();
+    }
+
+    @Override
+    public OutputStream getResponseBody() throws IOException {
+        return res.getOutputStream();
+    }
+
+    @Override
+    public void setStatus(int rCode) {
+        res.setStatus(rCode);
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return null;
+        // Only from 2.4
+        // return InetSocketAddress.createUnresolved(req.getRemoteAddr(), req.getRemotePort());
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+        return InetSocketAddress.createUnresolved(req.getServerName(), req.getServerPort());
+    }
+
+    @Override
+    public String getProtocol() {
+        return req.getProtocol();
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        if (name.equals(MessageContext.SERVLET_CONTEXT)) {
+            return servletContext;
+        } else if (name.equals(MessageContext.SERVLET_REQUEST)) {
+            return req;
+        } else if (name.equals(MessageContext.SERVLET_RESPONSE)) {
+            return res;
+        }
+        return null;
+    }
+
+    @Override
+    public Set<String> getAttributeNames() {
+        return attributes;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return req.getUserPrincipal();
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        return req.isUserInRole(role);
+    }
+
+    @Override
+    public String getScheme() {
+        return req.getScheme();
+    }
+
+    @Override
+    public String getPathInfo() {
+        return req.getPathInfo();
+    }
+
+    @Override
+    public String getQueryString() {
+        return req.getQueryString();
+    }
+}

--- a/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/wsri/ExchangeRequestHeaders.java
+++ b/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/wsri/ExchangeRequestHeaders.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.eclipse.osgi.technology.webservices.httpwhiteboard.wsri;
+
+
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.xml.ws.spi.http.HttpExchange;
+
+/**
+ * {@link HttpExchange#getRequestHeaders} impl for servlet container.
+ *
+ * @author Jitendra Kotamraju
+ */
+class ExchangeRequestHeaders extends Headers {
+    private final HttpServletRequest request;
+    private boolean useMap = false;
+
+    ExchangeRequestHeaders(HttpServletRequest request) {
+        this.request = request;
+    }
+
+    private void convertToMap() {
+        if (!useMap) {
+            Enumeration e = request.getHeaderNames();
+            while(e.hasMoreElements()) {
+                String name = (String)e.nextElement();
+                Enumeration ev = request.getHeaders(name);
+                while(ev.hasMoreElements()) {
+                    String value = (String)ev.nextElement();
+                    super.add(name, value);
+                }
+            }
+            useMap = true;
+        }
+    }
+
+    @Override
+    public int size() {
+        convertToMap();
+        return super.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        convertToMap();
+        return super.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        if (!(key instanceof String)) {
+            return false;
+        }
+        return useMap ? super.containsKey(key) : request.getHeader((String)key) != null;
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        convertToMap();
+        return super.containsValue(value);
+    }
+
+    @Override
+    public List<String> get(Object key) {
+        convertToMap();
+        return super.get(key);
+    }
+
+    @Override
+    public String getFirst(String key) {
+        return useMap ? super.getFirst(key) : request.getHeader(key);
+    }
+
+    @Override
+    public List<String> put(String key, List<String> value) {
+        convertToMap();
+        return super.put(key, value);
+    }
+
+    @Override
+    public void add(String key, String value) {
+        convertToMap();
+        super.add(key, value);
+    }
+
+    @Override
+    public void set(String key, String value) {
+        convertToMap();
+        super.set(key, value);
+    }
+    @Override
+    public List<String> remove(Object key) {
+        convertToMap();
+        return super.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends List<String>> t) {
+        convertToMap();
+        super.putAll(t);
+    }
+
+    @Override
+    public void clear() {
+        convertToMap();
+        super.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        convertToMap();
+        return super.keySet();
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        convertToMap();
+        return super.values();
+    }
+
+    @Override
+    public Set<Entry<String, List<String>>> entrySet() {
+        convertToMap();
+        return super.entrySet();
+    }
+
+    @Override
+    public String toString() {
+        convertToMap();
+        return super.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+}

--- a/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/wsri/ExchangeResponseHeaders.java
+++ b/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/wsri/ExchangeResponseHeaders.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.eclipse.osgi.technology.webservices.httpwhiteboard.wsri;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.xml.ws.spi.http.HttpExchange;
+
+/**
+ * {@link HttpExchange#getResponseHeaders} impl for servlet container.
+ *
+ * @author Jitendra Kotamraju
+ */
+class ExchangeResponseHeaders extends Headers {
+    private final HttpServletResponse response;
+
+    ExchangeResponseHeaders(HttpServletResponse response) {
+        this.response = response;
+    }
+
+    @Override
+    public int size() {
+        return super.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return super.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return super.containsValue(value);
+    }
+
+    @Override
+    public List<String> get(Object key) {
+        return super.get(key);
+    }
+
+    @Override
+    public String getFirst(String key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> put(String key, List<String> value) {
+        for(String val : value) {
+            response.addHeader(key, val);
+        }
+        return super.put(key, value);
+    }
+
+    @Override
+    public void add(String key, String value) {
+        response.addHeader(key, value);
+        super.add(key, value);
+    }
+
+    @Override
+    public void set(String key, String value) {
+        response.addHeader(key, value);
+        super.set(key, value);
+    }
+
+    @Override
+    public List<String> remove(Object key) {
+        //TODO how to delete a header in response
+        return super.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends List<String>> t) {
+        // TODO
+        super.putAll(t);
+    }
+
+    @Override
+    public void clear() {
+        // TODO
+        super.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return super.keySet();
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        return super.values();
+    }
+
+    @Override
+    public Set<Entry<String, List<String>>> entrySet() {
+        return super.entrySet();
+    }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/wsri/Headers.java
+++ b/runtime/httpwhiteboard/src/main/java/org/eclipse/osgi/technology/webservices/httpwhiteboard/wsri/Headers.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.eclipse.osgi.technology.webservices.httpwhiteboard.wsri;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * HTTP request and response headers are represented by this class which implements
+ * the interface {@link java.util.Map}&lt;
+ * {@link String},{@link java.util.List}&lt;{@link String}&gt;&gt;.
+ * The keys are case-insensitive Strings representing the header names and
+ * the value associated with each key is a {@link java.util.List}&lt;{@link String}&gt; with one
+ * element for each occurence of the header name in the request or response.
+ * <p>
+ * For example, if a response header instance contains one key "HeaderName" with two values "value1 and value2"
+ * then this object is output as two header lines:
+ * <pre>
+ * HeaderName: value1
+ * HeaderName: value2
+ * </pre>
+ * <p>
+ * All the normal {@link java.util.Map} methods are provided, but the following
+ * additional convenience methods are most likely to be used:
+ * <ul>
+ * <li>{@link #getFirst(String)} returns a single valued header or the first value of
+ * a multi-valued header.</li>
+ * <li>{@link #add(String,String)} adds the given header value to the list for the given key</li>
+ * <li>{@link #set(String,String)} sets the given header field to the single value given
+ * overwriting any existing values in the value list.
+ * </ul><p>
+ * All methods in this class accept <code>null</code> values for keys and values. However, null
+ * keys will never will be present in HTTP request headers, and will not be output/sent in response headers.
+ * Null values can be represented as either a null entry for the key (i.e. the list is null) or
+ * where the key has a list, but one (or more) of the list's values is null. Null values are output
+ * as a header line containing the key but no associated value.
+ * @since 1.6
+ */
+public class Headers implements Map<String,List<String>> {
+
+    HashMap<String,List<String>> map;
+
+    public Headers() {
+        map = new HashMap<>(32);
+    }
+
+    /* Normalize the key by converting to following form.
+     * First char upper case, rest lower case.
+     * key is presumed to be ASCII
+     */
+    private String normalize (String key) {
+        if (key == null) {
+            return null;
+        }
+        int len = key.length();
+        if (len == 0) {
+            return key;
+        }
+        char[] b;
+        String s;
+        b = key.toCharArray();
+        if (b[0] >= 'a' && b[0] <= 'z') {
+            b[0] = (char) (b[0] - ('a' - 'A'));
+        }
+        for (int i = 1; i < len; i++) {
+            if (b[i] >= 'A' && b[i] <= 'Z') {
+                b[i] = (char) (b[i] + ('a' - 'A'));
+            }
+        }
+        s = new String(b);
+        return s;
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        if (key == null) {
+            return false;
+        }
+        if (!(key instanceof String)) {
+            return false;
+        }
+        return map.containsKey (normalize((String)key));
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public List<String> get(Object key) {
+        return map.get(normalize((String)key));
+    }
+
+    /**
+     * returns the first value from the List of String values
+     * for the given key (if at least one exists).
+     * @param key the key to search for
+     * @return the first string value associated with the key
+     */
+    public String getFirst (String key) {
+        List<String> l = map.get(normalize(key));
+        if (l == null) {
+            return null;
+        }
+        return l.get(0);
+    }
+
+    @Override
+    public List<String> put(String key, List<String> value) {
+        return map.put (normalize(key), value);
+    }
+
+    /**
+     * adds the given value to the list of headers
+     * for the given key. If the mapping does not
+     * already exist, then it is created
+     * @param key the header name
+     * @param value the header value to add to the header
+     */
+    public void add (String key, String value) {
+        String k = normalize(key);
+        List<String> l = map.get(k);
+        if (l == null) {
+            l = new LinkedList<>();
+            map.put(k,l);
+        }
+        l.add (value);
+    }
+
+    /**
+     * sets the given value as the sole header value
+     * for the given key. If the mapping does not
+     * already exist, then it is created
+     * @param key the header name
+     * @param value the header value to set.
+     */
+    public void set (String key, String value) {
+        LinkedList<String> l = new LinkedList<>();
+        l.add (value);
+        put (key, l);
+    }
+
+
+    @Override
+    public List<String> remove(Object key) {
+        return map.remove(normalize((String)key));
+    }
+
+    @Override
+    public void putAll(Map<? extends String,? extends List<String>> t)  {
+        for(Entry<? extends String, ? extends List<String>> entry : t.entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return map.keySet();
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        return map.values();
+    }
+
+    @Override
+    public Set<Entry<String, List<String>>> entrySet() {
+        return map.entrySet();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return map.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return map.toString();
+    }
+}

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -23,5 +23,6 @@
   <packaging>pom</packaging>
   <modules>
     <module>registrar</module>
-  </modules>
+    <module>httpwhiteboard</module>
+   </modules>
 </project>


### PR DESCRIPTION
this adds an implementation of the publisher SPI that uses the http whiteboard as its backend implementation.

**THIS IS CURRENTLY A DRAFT**

- [ ] Cleanups
- [ ] add tests
- [ ] Either check with the IP team if we can embeds the source of jax-ws-ri here or find some way to use them directly (reflection, dynamic imports, ...)