### PR TITLE
Implement service change count and adjust ordering to latest changes

### DIFF
--- a/runtime/registrar/pom.xml
+++ b/runtime/registrar/pom.xml
@@ -41,5 +41,11 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component</artifactId>
     </dependency>
+    <dependency>
+    <groupId>org.osgi</groupId>
+    <artifactId>org.osgi.namespace.implementation</artifactId>
+    <version>1.0.0</version>
+</dependency>
+
   </dependencies>
 </project>

--- a/runtime/registrar/src/main/java/org/eclipse/osgi/technology/webservices/registrar/HandlerInfo.java
+++ b/runtime/registrar/src/main/java/org/eclipse/osgi/technology/webservices/registrar/HandlerInfo.java
@@ -30,24 +30,26 @@ import jakarta.xml.ws.handler.MessageContext;
 
 final class HandlerInfo {
 
-    static final Comparator<HandlerInfo> SORT_BY_PRIORITY = Comparator.comparingInt(HandlerInfo::getPriority)
-            .reversed();
+	static final Comparator<HandlerInfo> SORT_BY_PRIORITY = Comparator.comparingInt(HandlerInfo::getServiceRank)
+			.reversed().thenComparing(HandlerInfo::getServiceId);
     private final ServiceReference<Handler<? extends MessageContext>> reference;
-    private final int priority;
+    private final int serviceRank;
     private BundleContext bundleContext;
     private Handler<? extends MessageContext> service;
     private Exception lookupError;
     private Exception filterError;
+	private long serviceId;
 
     HandlerInfo(ServiceReference<Handler<? extends MessageContext>> reference, BundleContext bundleContext) {
         this.reference = reference;
         this.bundleContext = bundleContext;
         Integer p = (Integer) reference.getProperty(Constants.SERVICE_RANKING);
         if (p == null) {
-            this.priority = 0;
+            this.serviceRank = 0;
         } else {
-            this.priority = p.intValue();
+            this.serviceRank = p.intValue();
         }
+		serviceId = (Long) reference.getProperty(Constants.SERVICE_ID);
     }
 
     synchronized boolean matches(ServiceReference<?> endpointImplementor) {
@@ -73,9 +75,13 @@ final class HandlerInfo {
         return false;
     }
 
-    int getPriority() {
-        return priority;
-    }
+	public int getServiceRank() {
+		return serviceRank;
+	}
+
+	public long getServiceId() {
+		return serviceId;
+	}
 
     synchronized void dispose() {
         try {

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -82,7 +82,9 @@
       <version>2.4.0</version>
       <type>jar</type>
     </dependency>
-
-
+    <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.test.junit5</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This implements a change count for the runtime service and slightly adjust the ordering of handlers according to latest spec changes.

FYI @stbischof @timothyjward 

Will fix:
- https://github.com/eclipse-osgi-technology/jakarta-webservices/issues/8