### PR TITLE
Fix handler ranking updates not being applied to endpoint DTOs

### DIFF
--- a/runtime/registrar/src/main/java/org/eclipse/osgi/technology/webservices/registrar/EndpointRegistrar.java
+++ b/runtime/registrar/src/main/java/org/eclipse/osgi/technology/webservices/registrar/EndpointRegistrar.java
@@ -178,7 +178,7 @@ public class EndpointRegistrar implements WebserviceServiceRuntime {
      * @param handler handler
      */
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, target = "("
-            + WebserviceWhiteboardConstants.WEBSERVICE_HANDLER_EXTENSION + "=true)")
+            + WebserviceWhiteboardConstants.WEBSERVICE_HANDLER_EXTENSION + "=true)", updated = "updateHandler")
     public void addHandler(ServiceReference<Handler<? extends MessageContext>> handler) {
         logger.debug("ADD handler={}", handler);
         HandlerInfo info = handlerMap.put(handler, new HandlerInfo(handler, context.getBundleContext()));

--- a/tests/src/test/java/org/osgi/test/cases/webservice/junit/HandlerRegistrationTests.java
+++ b/tests/src/test/java/org/osgi/test/cases/webservice/junit/HandlerRegistrationTests.java
@@ -398,7 +398,6 @@ public class HandlerRegistrationTests {
      * @throws Exception
      */
     @Test
-    @Disabled
     public void testHandlersOrdering() throws Exception {
         // Register Case Change then Reverse
         Callable<List<ServiceRegistration<?>>> action = () -> {


### PR DESCRIPTION
Declare explicit `updated` callback on the Handler reference so SCR invokes updateHandler() when service properties (e.g. service.ranking) change, refreshing the handler chain order. Also re-enables HandlerRegistrationTests.testHandlersOrdering.